### PR TITLE
Add mint math types implementations

### DIFF
--- a/examples/move.rs
+++ b/examples/move.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-use qilin::Vector2;
 use qilin::game::context::GameContext;
 use qilin::game::game::Game;
 use qilin::render::canvas::Canvas;
@@ -8,9 +6,11 @@ use qilin::render::sketch::Sketch;
 use qilin::scene::Scene;
 use qilin::simplified::vec2;
 use qilin::types::{GameConfig, FPS60};
-use qilin::ScaleMode;
-use qilin::WindowOptions;
 use qilin::Key;
+use qilin::ScaleMode;
+use qilin::Vector2;
+use qilin::WindowOptions;
+use std::time::Duration;
 
 const MAX_Y: u32 = 560;
 const MAX_X: u32 = 760;

--- a/src/game/game.rs
+++ b/src/game/game.rs
@@ -1,9 +1,9 @@
-use std::time::{Duration, Instant};
 use crate::game::context::GameContext;
 use crate::render::canvas::Canvas;
 use crate::scene::Scene;
 use crate::types::GameConfig;
 use minifb::Window;
+use std::time::{Duration, Instant};
 
 /// Main Game initiator to run window and enter scenes.
 pub struct Game {
@@ -78,11 +78,13 @@ impl Game {
 
             canvas.cleanse();
 
-            self.scene.update(&mut canvas, &mut GameContext::new(&mut window));
+            self.scene
+                .update(&mut canvas, &mut GameContext::new(&mut window));
 
             // Call fixed_update multiple times if necessary.
             while accumulated_time >= fixed_time_step {
-                self.scene.fixed_update(&mut canvas, &mut GameContext::new(&mut window));
+                self.scene
+                    .fixed_update(&mut canvas, &mut GameContext::new(&mut window));
                 accumulated_time -= fixed_time_step;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 /// Contains structs for game control and windowing.
 pub mod game;
+/// Contains math functions to manipulate `mint` types, like [Vector2] or [Vector3].
+pub mod math;
 /// Contains structs for the [game] module to use. Mostly rendering and geometry stuff.
 pub mod render;
 /// Contains the [scene::Scene] trait.
@@ -8,8 +10,6 @@ pub mod scene;
 pub mod simplified;
 /// Contains common types of qilin.
 pub mod types;
-/// Contains math functions to manipulate `mint` types, like [Vector2] or [Vector3].
-pub mod math;
 
 /// Contains utils for converting images from the `image` crate to a qilin [types::Image].\
 /// Requires `image` feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod scene;
 pub mod simplified;
 /// Contains common types of qilin.
 pub mod types;
+/// Contains math functions to manipulate `mint` types, like [Vector2] or [Vector3].
+pub mod math;
 
 /// Contains utils for converting images from the `image` crate to a qilin [types::Image].\
 /// Requires `image` feature.

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,8 +1,8 @@
+/// Extension for the [Quaternion](mint::Quaternion) type.
+pub mod quat;
 /// Extension for the [Vector2](mint::Vector2) type.
 pub mod vec2;
 /// Extension for the [Vector3](mint::Vector3) type.
 pub mod vec3;
 /// Extension for the [Vector4](mint::Vector4) type.
 pub mod vec4;
-/// Extension for the [Quaternion](mint::Quaternion) type.
-pub mod quat;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,0 +1,8 @@
+/// Extension for the [Vector2](mint::Vector2) type.
+pub mod vec2;
+/// Extension for the [Vector3](mint::Vector3) type.
+pub mod vec3;
+/// Extension for the [Vector4](mint::Vector4) type.
+pub mod vec4;
+/// Extension for the [Quaternion](mint::Quaternion) type.
+pub mod quat;

--- a/src/math/quat.rs
+++ b/src/math/quat.rs
@@ -1,0 +1,82 @@
+use mint::Quaternion;
+use std::ops::{Add, Sub, Mul, Div};
+
+/// Trait to extend the `Vector2` struct from the `mint` crate.
+pub trait QuatExt<T>
+    where
+        T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
+{
+    fn magnitude(&self) -> T;
+    fn normalize(&self) -> Quaternion<T>;
+    fn conjugate(&self) -> Quaternion<T>;
+    fn dot(&self, other: &Quaternion<T>) -> T;
+}
+
+// Extend Vector2 with T = f32
+impl QuatExt<f32> for Quaternion<f32> {
+    fn magnitude(&self) -> f32 {
+        (self.s * self.s + self.v.x * self.v.x + self.v.y * self.v.y + self.v.z * self.v.z).sqrt()
+    }
+
+    fn normalize(&self) -> Quaternion<f32> {
+        let mag = self.magnitude();
+        Quaternion {
+            s: self.s / mag,
+            v: mint::Vector3 {
+                x: self.v.x / mag,
+                y: self.v.y / mag,
+                z: self.v.z / mag,
+            },
+        }
+    }
+
+    fn conjugate(&self) -> Quaternion<f32> {
+        Quaternion {
+            s: self.s,
+            v: mint::Vector3 {
+                x: -self.v.x,
+                y: -self.v.y,
+                z: -self.v.z,
+            },
+        }
+    }
+
+    fn dot(&self, other: &Quaternion<f32>) -> f32 {
+        self.s * other.s + self.v.x * other.v.x + self.v.y * other.v.y + self.v.z * other.v.z
+    }
+}
+
+// Extend Vector2 with T = u32
+impl QuatExt<u32> for Quaternion<u32> {
+    fn magnitude(&self) -> u32 {
+        ((self.s * self.s + self.v.x * self.v.x + self.v.y * self.v.y + self.v.z * self.v.z) as f64)
+            .sqrt() as u32
+    }
+
+    fn normalize(&self) -> Quaternion<u32> {
+        let mag = self.magnitude();
+        Quaternion {
+            s: self.s / mag,
+            v: mint::Vector3 {
+                x: self.v.x / mag,
+                y: self.v.y / mag,
+                z: self.v.z / mag,
+            },
+        }
+    }
+
+    fn conjugate(&self) -> Quaternion<u32> {
+        Quaternion {
+            s: self.s,
+            v: mint::Vector3 {
+                x: self.v.x,
+                y: self.v.y,
+                z: self.v.z,
+            },
+        }
+    }
+
+    fn dot(&self, other: &Quaternion<u32>) -> u32 {
+        self.s * other.s + self.v.x * other.v.x + self.v.y * other.v.y + self.v.z * other.v.z
+    }
+}

--- a/src/math/quat.rs
+++ b/src/math/quat.rs
@@ -1,10 +1,10 @@
 use mint::Quaternion;
-use std::ops::{Add, Sub, Mul, Div};
+use std::ops::{Add, Div, Mul, Sub};
 
 /// Trait to extend the `Vector2` struct from the `mint` crate.
 pub trait QuatExt<T>
-    where
-        T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
+where
+    T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
 {
     fn magnitude(&self) -> T;
     fn normalize(&self) -> Quaternion<T>;

--- a/src/math/vec2.rs
+++ b/src/math/vec2.rs
@@ -1,10 +1,10 @@
 use mint::Vector2;
-use std::ops::{Add, Sub, Mul, Div};
+use std::ops::{Add, Div, Mul, Sub};
 
 /// Trait to extend the `Vector2` struct from the `mint` crate.
 pub trait Vector2Ext<T>
-    where
-        T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
+where
+    T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
 {
     fn magnitude(&self) -> T;
     fn normalize(&self) -> Vector2<T>;
@@ -17,9 +17,7 @@ pub trait Vector2Ext<T>
 
 // Extend Vector2 with T = f32
 impl Vector2Ext<f32> for Vector2<f32> {
-    fn magnitude(&self) -> f32 {
-        (self.x * self.x + self.y * self.y).sqrt()
-    }
+    fn magnitude(&self) -> f32 { (self.x * self.x + self.y * self.y).sqrt() }
 
     fn normalize(&self) -> Vector2<f32> {
         let mag = self.magnitude();
@@ -29,13 +27,9 @@ impl Vector2Ext<f32> for Vector2<f32> {
         }
     }
 
-    fn dot(&self, other: &Vector2<f32>) -> f32 {
-        self.x * other.x + self.y * other.y
-    }
+    fn dot(&self, other: &Vector2<f32>) -> f32 { self.x * other.x + self.y * other.y }
 
-    fn cross(&self, other: &Vector2<f32>) -> f32 {
-        self.x * other.y - self.y * other.x
-    }
+    fn cross(&self, other: &Vector2<f32>) -> f32 { self.x * other.y - self.y * other.x }
 
     fn distance(&self, other: &Vector2<f32>) -> f32 {
         let dx = self.x - other.x;
@@ -62,9 +56,7 @@ impl Vector2Ext<f32> for Vector2<f32> {
 
 // Extend Vector2 with T = u32
 impl Vector2Ext<u32> for Vector2<u32> {
-    fn magnitude(&self) -> u32 {
-        ((self.x * self.x + self.y * self.y) as f64).sqrt() as u32
-    }
+    fn magnitude(&self) -> u32 { ((self.x * self.x + self.y * self.y) as f64).sqrt() as u32 }
 
     fn normalize(&self) -> Vector2<u32> {
         let mag = self.magnitude();
@@ -74,13 +66,9 @@ impl Vector2Ext<u32> for Vector2<u32> {
         }
     }
 
-    fn dot(&self, other: &Vector2<u32>) -> u32 {
-        self.x * other.x + self.y * other.y
-    }
+    fn dot(&self, other: &Vector2<u32>) -> u32 { self.x * other.x + self.y * other.y }
 
-    fn cross(&self, other: &Vector2<u32>) -> u32 {
-        self.x * other.y - self.y * other.x
-    }
+    fn cross(&self, other: &Vector2<u32>) -> u32 { self.x * other.y - self.y * other.x }
 
     fn distance(&self, other: &Vector2<u32>) -> u32 {
         let dx = (self.x as i32 - other.x as i32).abs();

--- a/src/math/vec2.rs
+++ b/src/math/vec2.rs
@@ -1,0 +1,112 @@
+use mint::Vector2;
+use std::ops::{Add, Sub, Mul, Div};
+
+/// Trait to extend the `Vector2` struct from the `mint` crate.
+pub trait Vector2Ext<T>
+    where
+        T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
+{
+    fn magnitude(&self) -> T;
+    fn normalize(&self) -> Vector2<T>;
+    fn dot(&self, other: &Vector2<T>) -> T;
+    fn cross(&self, other: &Vector2<T>) -> T;
+    fn distance(&self, other: &Vector2<T>) -> T;
+    fn angle(&self, other: &Vector2<T>) -> T;
+    fn rotate(&self, angle: T) -> Vector2<T>;
+}
+
+// Extend Vector2 with T = f32
+impl Vector2Ext<f32> for Vector2<f32> {
+    fn magnitude(&self) -> f32 {
+        (self.x * self.x + self.y * self.y).sqrt()
+    }
+
+    fn normalize(&self) -> Vector2<f32> {
+        let mag = self.magnitude();
+        Vector2 {
+            x: self.x / mag,
+            y: self.y / mag,
+        }
+    }
+
+    fn dot(&self, other: &Vector2<f32>) -> f32 {
+        self.x * other.x + self.y * other.y
+    }
+
+    fn cross(&self, other: &Vector2<f32>) -> f32 {
+        self.x * other.y - self.y * other.x
+    }
+
+    fn distance(&self, other: &Vector2<f32>) -> f32 {
+        let dx = self.x - other.x;
+        let dy = self.y - other.y;
+        (dx * dx + dy * dy).sqrt()
+    }
+
+    fn angle(&self, other: &Vector2<f32>) -> f32 {
+        let dot_product = self.dot(other);
+        let self_magnitude = self.magnitude();
+        let other_magnitude = other.magnitude();
+        (dot_product / (self_magnitude * other_magnitude)).acos()
+    }
+
+    fn rotate(&self, angle: f32) -> Vector2<f32> {
+        let cos_angle = angle.cos();
+        let sin_angle = angle.sin();
+        Vector2 {
+            x: self.x * cos_angle - self.y * sin_angle,
+            y: self.x * sin_angle + self.y * cos_angle,
+        }
+    }
+}
+
+// Extend Vector2 with T = u32
+impl Vector2Ext<u32> for Vector2<u32> {
+    fn magnitude(&self) -> u32 {
+        ((self.x * self.x + self.y * self.y) as f64).sqrt() as u32
+    }
+
+    fn normalize(&self) -> Vector2<u32> {
+        let mag = self.magnitude();
+        Vector2 {
+            x: self.x / mag,
+            y: self.y / mag,
+        }
+    }
+
+    fn dot(&self, other: &Vector2<u32>) -> u32 {
+        self.x * other.x + self.y * other.y
+    }
+
+    fn cross(&self, other: &Vector2<u32>) -> u32 {
+        self.x * other.y - self.y * other.x
+    }
+
+    fn distance(&self, other: &Vector2<u32>) -> u32 {
+        let dx = (self.x as i32 - other.x as i32).abs();
+        let dy = (self.y as i32 - other.y as i32).abs();
+        ((dx * dx + dy * dy) as f64).sqrt() as u32
+    }
+
+    fn angle(&self, other: &Vector2<u32>) -> u32 {
+        let dot_product = self.dot(other) as f64;
+        let self_magnitude = self.magnitude() as f64;
+        let other_magnitude = other.magnitude() as f64;
+
+        // Calculate the angle in radians
+        let angle_radians = (dot_product / (self_magnitude * other_magnitude)).acos();
+
+        // Convert the angle to degrees
+        let angle_degrees = angle_radians.to_degrees() as u32;
+        angle_degrees
+    }
+
+    fn rotate(&self, angle: u32) -> Vector2<u32> {
+        let cos_angle = (angle as f32).cos();
+        let sin_angle = (angle as f32).sin();
+        Vector2 {
+            x: ((self.x as f32 * cos_angle - self.y as f32 * sin_angle) as u32),
+            y: ((self.x as f32 * sin_angle + self.y as f32 * cos_angle) as u32),
+        }
+    }
+}

--- a/src/math/vec3.rs
+++ b/src/math/vec3.rs
@@ -1,0 +1,69 @@
+use mint::Vector3;
+use std::ops::{Add, Sub, Mul, Div};
+
+/// Trait to extend the `Vector3` struct from the `mint` crate.
+pub trait Vector3Ext<T>
+    where
+        T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
+{
+    fn magnitude(&self) -> T;
+    fn normalize(&self) -> Vector3<T>;
+    fn dot(&self, other: &Vector3<T>) -> T;
+    fn cross(&self, other: &Vector3<T>) -> Vector3<T>;
+}
+
+// Extend Vector3 with T = f32
+impl Vector3Ext<f32> for Vector3<f32> {
+    fn magnitude(&self) -> f32 {
+        (self.x * self.x + self.y * self.y + self.z * self.z).sqrt()
+    }
+
+    fn normalize(&self) -> Vector3<f32> {
+        let mag = self.magnitude();
+        Vector3 {
+            x: self.x / mag,
+            y: self.y / mag,
+            z: self.z / mag,
+        }
+    }
+
+    fn dot(&self, other: &Vector3<f32>) -> f32 {
+        self.x * other.x + self.y * other.y + self.z * other.z
+    }
+
+    fn cross(&self, other: &Vector3<f32>) -> Vector3<f32> {
+        Vector3 {
+            x: self.y * other.z - self.z * other.y,
+            y: self.z * other.x - self.x * other.z,
+            z: self.x * other.y - self.y * other.x,
+        }
+    }
+}
+
+// Extend Vector3 with T = u32
+impl Vector3Ext<u32> for Vector3<u32> {
+    fn magnitude(&self) -> u32 {
+        ((self.x * self.x + self.y * self.y + self.z * self.z) as f64).sqrt() as u32
+    }
+
+    fn normalize(&self) -> Vector3<u32> {
+        let mag = self.magnitude();
+        Vector3 {
+            x: self.x / mag,
+            y: self.y / mag,
+            z: self.z / mag,
+        }
+    }
+
+    fn dot(&self, other: &Vector3<u32>) -> u32 {
+        self.x * other.x + self.y * other.y + self.z * other.z
+    }
+
+    fn cross(&self, other: &Vector3<u32>) -> Vector3<u32> {
+        Vector3 {
+            x: self.y * other.z - self.z * other.y,
+            y: self.z * other.x - self.x * other.z,
+            z: self.x * other.y - self.y * other.x,
+        }
+    }
+}

--- a/src/math/vec3.rs
+++ b/src/math/vec3.rs
@@ -1,10 +1,10 @@
 use mint::Vector3;
-use std::ops::{Add, Sub, Mul, Div};
+use std::ops::{Add, Div, Mul, Sub};
 
 /// Trait to extend the `Vector3` struct from the `mint` crate.
 pub trait Vector3Ext<T>
-    where
-        T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
+where
+    T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
 {
     fn magnitude(&self) -> T;
     fn normalize(&self) -> Vector3<T>;
@@ -14,9 +14,7 @@ pub trait Vector3Ext<T>
 
 // Extend Vector3 with T = f32
 impl Vector3Ext<f32> for Vector3<f32> {
-    fn magnitude(&self) -> f32 {
-        (self.x * self.x + self.y * self.y + self.z * self.z).sqrt()
-    }
+    fn magnitude(&self) -> f32 { (self.x * self.x + self.y * self.y + self.z * self.z).sqrt() }
 
     fn normalize(&self) -> Vector3<f32> {
         let mag = self.magnitude();

--- a/src/math/vec4.rs
+++ b/src/math/vec4.rs
@@ -1,10 +1,10 @@
 use mint::Vector4;
-use std::ops::{Add, Sub, Mul, Div};
+use std::ops::{Add, Div, Mul, Sub};
 
 /// Trait to extend the `Vector4` struct from the `mint` crate.
 pub trait Vector4Ext<T>
-    where
-        T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
+where
+    T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
 {
     fn magnitude(&self) -> T;
     fn normalize(&self) -> Vector4<T>;
@@ -35,7 +35,8 @@ impl Vector4Ext<f32> for Vector4<f32> {
 // Extend Vector4 with T = f32
 impl Vector4Ext<u32> for Vector4<u32> {
     fn magnitude(&self) -> u32 {
-        ((self.x * self.x + self.y * self.y + self.z * self.z + self.w * self.w) as f64).sqrt() as u32
+        ((self.x * self.x + self.y * self.y + self.z * self.z + self.w * self.w) as f64).sqrt()
+            as u32
     }
 
     fn normalize(&self) -> Vector4<u32> {

--- a/src/math/vec4.rs
+++ b/src/math/vec4.rs
@@ -1,0 +1,54 @@
+use mint::Vector4;
+use std::ops::{Add, Sub, Mul, Div};
+
+/// Trait to extend the `Vector4` struct from the `mint` crate.
+pub trait Vector4Ext<T>
+    where
+        T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Copy,
+{
+    fn magnitude(&self) -> T;
+    fn normalize(&self) -> Vector4<T>;
+    fn dot(&self, other: &Vector4<T>) -> T;
+}
+
+// Extend Vector4 with T = f32
+impl Vector4Ext<f32> for Vector4<f32> {
+    fn magnitude(&self) -> f32 {
+        (self.x * self.x + self.y * self.y + self.z * self.z + self.w * self.w).sqrt()
+    }
+
+    fn normalize(&self) -> Vector4<f32> {
+        let mag = self.magnitude();
+        Vector4 {
+            x: self.x / mag,
+            y: self.y / mag,
+            z: self.z / mag,
+            w: self.w / mag,
+        }
+    }
+
+    fn dot(&self, other: &Vector4<f32>) -> f32 {
+        self.x * other.x + self.y * other.y + self.z * other.z + self.w * other.w
+    }
+}
+
+// Extend Vector4 with T = f32
+impl Vector4Ext<u32> for Vector4<u32> {
+    fn magnitude(&self) -> u32 {
+        ((self.x * self.x + self.y * self.y + self.z * self.z + self.w * self.w) as f64).sqrt() as u32
+    }
+
+    fn normalize(&self) -> Vector4<u32> {
+        let mag = self.magnitude();
+        Vector4 {
+            x: self.x / mag,
+            y: self.y / mag,
+            z: self.z / mag,
+            w: self.w / mag,
+        }
+    }
+
+    fn dot(&self, other: &Vector4<u32>) -> u32 {
+        self.x * other.x + self.y * other.y + self.z * other.z + self.w * other.w
+    }
+}

--- a/src/render/sketch.rs
+++ b/src/render/sketch.rs
@@ -125,8 +125,12 @@ impl Operation {
     #[inline(never)]
     pub fn apply(&self, canvas: &mut Canvas) {
         match self {
-
-            Operation::Oval { pos, width, height, color } => {
+            Operation::Oval {
+                pos,
+                width,
+                height,
+                color,
+            } => {
                 let start_x = pos.x;
                 let start_y = pos.y;
                 let end_x = start_x + *width;


### PR DESCRIPTION
Added following extensions (traits) for types of the `mint` crate:
* Vector2Ext Trait + impl for u32 & f32
* Vector3Ext Trait + impl for u32 & f32
* Vector4Ext Trait + impl for u32 & f32
* QuatExt Trait + impl for u32 & f32