### PR TITLE
Add TimeStamp struct

### DIFF
--- a/examples/move.rs
+++ b/examples/move.rs
@@ -7,7 +7,7 @@ use qilin::render::color::Color;
 use qilin::render::sketch::Sketch;
 use qilin::scene::Scene;
 use qilin::simplified::vec2;
-use qilin::types::{GameConfig, FPS60, TimeStamp};
+use qilin::types::{GameConfig, TimeStamp, FPS60};
 use qilin::Key;
 use qilin::ScaleMode;
 use qilin::Vector2;

--- a/examples/move.rs
+++ b/examples/move.rs
@@ -7,7 +7,7 @@ use qilin::render::color::Color;
 use qilin::render::sketch::Sketch;
 use qilin::scene::Scene;
 use qilin::simplified::vec2;
-use qilin::types::{GameConfig, FPS60};
+use qilin::types::{GameConfig, FPS60, TimeStamp};
 use qilin::Key;
 use qilin::ScaleMode;
 use qilin::Vector2;
@@ -85,7 +85,7 @@ fn main() {
             update_rate_limit: FPS60,    // limit update rate to 30 fps, default is 60 fps
             width: 800,                  // set initial width
             height: 600,                 // set initial height
-            fixed_time_step: Duration::from_secs_f32(1.0 / 120.0), // how many times fixed_update will be called, (1.0 / 120.0) means 300 times per second.
+            fixed_time_step: TimeStamp(Duration::from_secs_f32(1.0 / 120.0)), // how many times fixed_update will be called, (1.0 / 120.0) means 120 times per second.
             window: WindowOptions {
                 scale_mode: ScaleMode::AspectRatioStretch, // scale pixels to fit in aspect ratio
                 resize: true,                              // make window resizeable

--- a/examples/prefs.rs
+++ b/examples/prefs.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use qilin::scene::Scene;
 
-use qilin::types::{GameConfig, FPS30};
+use qilin::types::{GameConfig, FPS30, TimeStamp};
 use qilin::Key;
 use qilin::ScaleMode;
 use qilin::WindowOptions;
@@ -86,7 +86,7 @@ fn main() {
             update_rate_limit: FPS30,       // limit update rate to 30 fps, default is 60 fps
             width: 800,                     // set initial width
             height: 600,                    // set initial height
-            fixed_time_step: Duration::from_secs_f32(1.0 / 10.0), // for better docs, see GameConfig or examples/move.
+            fixed_time_step: TimeStamp(Duration::from_secs_f32(1.0 / 10.0)), // for better docs, see GameConfig or examples/move.
             window: WindowOptions {
                 scale_mode: ScaleMode::AspectRatioStretch, // scale pixels to fit in aspect ratio
                 resize: true,                              // make window resizeable

--- a/examples/prefs.rs
+++ b/examples/prefs.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use qilin::scene::Scene;
 
-use qilin::types::{GameConfig, FPS30, TimeStamp};
+use qilin::types::{GameConfig, TimeStamp, FPS30};
 use qilin::Key;
 use qilin::ScaleMode;
 use qilin::WindowOptions;

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -1,6 +1,5 @@
 //! Demonstrates common shape drawing.
 
-use std::time::Duration;
 use qilin::game::context::GameContext;
 use qilin::game::game::Game;
 use qilin::render::canvas::Canvas;
@@ -11,6 +10,7 @@ use qilin::simplified::vec2;
 use qilin::types::{GameConfig, FPS30, FPS60};
 use qilin::ScaleMode;
 use qilin::WindowOptions;
+use std::time::Duration;
 
 struct ShapeScene;
 

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -1,5 +1,6 @@
 //! Demonstrates common shape drawing.
 
+use std::time::Duration;
 use qilin::game::context::GameContext;
 use qilin::game::game::Game;
 use qilin::render::canvas::Canvas;
@@ -7,7 +8,7 @@ use qilin::render::color::Color;
 use qilin::render::sketch::Sketch;
 use qilin::scene::Scene;
 use qilin::simplified::vec2;
-use qilin::types::{GameConfig, FPS30};
+use qilin::types::{GameConfig, FPS30, FPS60};
 use qilin::ScaleMode;
 use qilin::WindowOptions;
 

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -7,10 +7,10 @@ use qilin::render::color::Color;
 use qilin::render::sketch::Sketch;
 use qilin::scene::Scene;
 use qilin::simplified::vec2;
-use qilin::types::{GameConfig, FPS30, FPS60};
+use qilin::types::{GameConfig, FPS30};
 use qilin::ScaleMode;
 use qilin::WindowOptions;
-use std::time::Duration;
+
 
 struct ShapeScene;
 

--- a/src/game/game.rs
+++ b/src/game/game.rs
@@ -65,7 +65,7 @@ impl Game {
 
         let mut canvas = Canvas::new(*width, *height);
 
-        let fixed_time_step = self.config.fixed_time_step;
+        let fixed_time_step = self.config.fixed_time_step.0;
 
         let mut last_time = Instant::now();
         let mut accumulated_time = Duration::from_secs(0);

--- a/src/types.rs
+++ b/src/types.rs
@@ -48,9 +48,7 @@ pub struct TimeStamp(pub Duration);
 
 impl Default for TimeStamp {
     #[inline]
-    fn default() -> Self {
-        Self(Duration::from_secs_f32(1.0 / 60.0))
-    }
+    fn default() -> Self { Self(Duration::from_secs_f32(1.0 / 60.0)) }
 }
 
 /// Update Rate as Duration. Use `types::FPS30`, `types::FPS60` or `types::FPS120` for FPS 30, 60 or 120 fps.

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,7 +14,7 @@ pub struct GameConfig {
     /// Height of the window. Default is 600.
     pub height: usize,
     /// Defines the fixed time step and how many times [crate::scene::Scene::fixed_update] is called in one second. Default is [Duration::from_secs_f32(1.0 / 30.0)] meaning 30 times per second.
-    pub fixed_time_step: Duration,
+    pub fixed_time_step: TimeStamp,
     /// Window options.
     pub window: WindowOptions,
 }
@@ -27,7 +27,7 @@ impl Default for GameConfig {
             update_rate_limit: FPS60,
             width: 800,
             height: 600,
-            fixed_time_step: Duration::from_secs_f32(1.0 / 60.0),
+            fixed_time_step: TimeStamp::default(),
             window: WindowOptions {
                 borderless: false,
                 title: true,
@@ -39,6 +39,17 @@ impl Default for GameConfig {
                 none: false,
             },
         }
+    }
+}
+
+/// An alternative type to [Duration] to avoid [Default::default] issues.
+#[derive(Clone, Debug)]
+pub struct TimeStamp(pub Duration);
+
+impl Default for TimeStamp {
+    #[inline]
+    fn default() -> Self {
+        Self(Duration::from_secs_f32(1.0 / 60.0))
     }
 }
 


### PR DESCRIPTION
Added `TimeStamp` struct to avoid some issues with the `Default` trait, that occurred in the `shapes` example. 